### PR TITLE
Add field to set tag size as defined by AprilTag

### DIFF
--- a/apriltag.html
+++ b/apriltag.html
@@ -49,8 +49,15 @@
 				<input id="frm-id" name="id" type="number" min="0" value="0">
 			</div>
 			<div class="field">
-				<label for="frm-size">Size, mm:</label>
+				<label for="frm-size">Total Size, mm:</label>
 				<input id="frm-size" name="size" type="number" min="10" max="5000" value="100">
+			</div>
+			<div class="field">
+				<label for="frm-tag-size">
+					<span title="AprilTag defines the tag size as the distance between detection corners, not between the outside edges (which includes padding)">&#9432;</span>
+					Tag Size, mm:
+				</label>
+				<input id="frm-tag-size" name="tag-size" type="number" min="10" max="5000" value="100">
 			</div>
 			
 			
@@ -58,9 +65,6 @@
 
 		<div class="marker-id"></div>
 		<div class="marker"></div>
-		<div class="name_id_dimen">
-		<label id /label>
-			</div>
 		<div class="tools">
 			<a href="" class="save-button">Save</a> this marker as SVG, or
 			<a href="javascript:window.print()">open</a> standard browser's print dialog to print or get the PDF.

--- a/main.js
+++ b/main.js
@@ -1,35 +1,43 @@
 const mappings = {
     "tag16h5": {
         "file_prefix": "tag16_05_",
-        "viewBox": "0 0 80 80"
+        "viewBox": "0 0 80 80",
+		"tag_size_ratio": 6/8
     },
     "tag25h9": {
         "file_prefix": "tag25_09_",
-        "viewBox": "0 0 90 90"
+        "viewBox": "0 0 90 90",
+		"tag_size_ratio": 7/9
     },
     "tag36h11": {
         "file_prefix": "tag36_11_",
-        "viewBox": "0 0 100 100"
+        "viewBox": "0 0 100 100",
+		"tag_size_ratio": 8/10,
     },
     "tagCircle21h7": {
         "file_prefix": "tag21_07_",
-        "viewBox": "0 0 90 90"
+        "viewBox": "0 0 90 90",
+		"tag_size_ratio": 1.0
     },
     "tagCircle49h12": {
         "file_prefix": "tag49_12_",
-        "viewBox": "0 0 110 110"
+        "viewBox": "0 0 110 110",
+		"tag_size_ratio": 1.0
     },
     "tagCustom48h12": {
         "file_prefix": "tag48_12_",
-        "viewBox": "0 0 100 100"
+        "viewBox": "0 0 100 100",
+		"tag_size_ratio": 6/10,
     },
     "tagStandard41h12": {
         "file_prefix": "tag41_12_",
-        "viewBox": "0 0 90 90"
+        "viewBox": "0 0 90 90",
+		"tag_size_ratio": 5/9,
     },
     "tagStandard52h13": {
         "file_prefix": "tag52_13_",
-        "viewBox": "0 0 100 100"
+        "viewBox": "0 0 100 100",
+		"tag_size_ratio": 6/10
     }
 }
 
@@ -65,14 +73,33 @@ function init() {
 	var familySelect = document.querySelector('.setup select[name=dict]');
 	var markerIdInput = document.querySelector('.setup input[name=id]');
 	var sizeInput = document.querySelector('.setup input[name=size]');
+	var tagSizeInput = document.querySelector('.setup input[name=tag-size]');
 	var saveButton = document.querySelector('.save-button');
-	
+
 	function updateSize(){
 		var size = Number(sizeInput.value);
-		const svgElm = document.querySelector('.marker').firstElementChild
-		svgElm.setAttribute('width', size + 'mm');
-		svgElm.setAttribute('height', size + 'mm');
+		const svgElm = document.querySelector('.marker').firstElementChild;
+		if (!!svgElm) {
+			svgElm.setAttribute('width', size + 'mm');
+			svgElm.setAttribute('height', size + 'mm');
+		}
 	}
+
+	familySelect.addEventListener("change", function() {
+		sizeInput.dispatchEvent(new Event('change'));
+	});
+
+	sizeInput.addEventListener("change", function() {
+		var familyName = familySelect.options[familySelect.selectedIndex].value;
+		tagSizeInput.value = Math.round(this.value * mappings[familyName].tag_size_ratio * 10) / 10;
+		updateSize();
+	});
+	
+	tagSizeInput.addEventListener("change", function() {
+		var familyName = familySelect.options[familySelect.selectedIndex].value;
+		sizeInput.value = Math.round(this.value / mappings[familyName].tag_size_ratio * 10) / 10;
+		updateSize();
+	});
 
 	var updateTag = debounce(function() {
 		var sizeid = Number(sizeInput.value);
@@ -89,6 +116,7 @@ function init() {
 		})
 	}, 200)
 
+	sizeInput.dispatchEvent(new Event('change'));
 	updateTag();
 
 	familySelect.addEventListener('change', updateTag);


### PR DESCRIPTION
Currently, the size field sets the total size of the tag, i.e. the width/height of the entire image, including padding. However, AprilTag defines the tag size to be the distance between the detection corners, which is different than the size of the image. When tag detectors are used for localization, this is the size parameter they require.

This PR adds a new text box allowing users to explicitly set the AprilTag size. The total size and tag size are kept up to date with each other as they are modified using event listeners.